### PR TITLE
fix: Update logic to handle correct total test count

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,14 @@ if (
     addStyles();
   });
 
+  // Used when user navigates away from current spec within the test runner
+  // Stops the voice from continuing
   Cypress.on("window:unload", () => {
     const voice = window.speechSynthesis;
     voice.cancel();
   });
 
-  Cypress.on("test:after:run", (config, test) => {
+  Cypress.on("test:after:run", (_, test) => {
     // Additional context of test index
     // To account for loops where there is one test per describe and suite names may stay
     // And to account for both specs with multiple suites or only one suite
@@ -40,6 +42,8 @@ if (
     // Volume toggle for volume of spoken text
     const volume = window.top?.document.querySelector("#volume");
 
+    // Logic involved with waiting for the restart button to appear
+    // This signals the Cypress Test Runner has completed it's current run
     function waitForElement(selector, callback) {
       const observer = new MutationObserver((mutations, observer) => {
         const element = window.top?.document.querySelector(selector);
@@ -195,11 +199,6 @@ if (
 
     if (currentTestIsLast) {
       waitForElement(".restart", () => {
-        // Perform actions on the element
-        // Additional context of test index
-        // To account for loops where there is one test per describe and suite names may stay
-        // And to account for both specs with multiple suites or only one suite
-
         // Announce spec run result and/or total time based on provided environment variable(s)
         if (
           Cypress.env("voiceResultType") === "simple" &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-voice-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-voice-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "cypress": "^13.7.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-voice-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Voice plugin for the Cypress Test Runner",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
When tests were announced, there was a mismatch in total tests run versus the announced total. 

This effort simplifies the original logic in determining when to announce results and how to collect results. 

Instead of using the counts and checking against retries and skips, the plugin will now observe for the `.restart` button in the Cypress Test Runner, which displays once all available tests to run have completed.

In addition, the counts of passed, failed and pending (skipped) will be collected from the stats displayed in the test runner, rather than from test runnables themselves.