### PR TITLE
chore: Upgrade Cypress to version 15.10.0 and update README for expose variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ import "cypress-voice-plugin";
 
 ## 🦺 Setup
 
-Within `cypress open`, the voice plugin is enabled via a [Cypress environment variable](https://docs.cypress.io/guides/guides/environment-variables).
+Within `cypress open`, beginning in plugin version `2.0.0`, the voice plugin is enabled via a [Cypress expose variable](https://docs.cypress.io/api/cypress-api/expose).
 
 > [!NOTE]  
 > You can only enable a single value for `voiceResultType` at a time. `voiceResultType` and/or `voiceTime` can be enabled together or independently.
 
-| Environment variable | Value        | Can this variable alone enable plugin? | Purpose                                                                                                             | Sample Spoken Result                                          |
-| -------------------- | ------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| `voiceResultType`    | `"simple"`   | ✅ Yes                                 | High-level result of entire spec file run.                                                                          | "Spec passed."                                                |
-| `voiceResultType`    | `"detailed"` | ✅ Yes                                 | In addition to what is provided by `"simple"`, the counts of tests passed, passed with retries, failed and skipped. | "Spec failed: 1 test passed, 2 tests failed, 1 test skipped." |
-| `voiceTime`          | `true`       | ✅ Yes                                 | The time of entire spec file run.                                                                                   | "Total time: 34 seconds"                                      |
+| Expose variable   | Value        | Can this variable alone enable plugin? | Purpose                                                                                                             | Sample Spoken Result                                          |
+| ----------------- | ------------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `voiceResultType` | `"simple"`   | ✅ Yes                                 | High-level result of entire spec file run.                                                                          | "Spec passed."                                                |
+| `voiceResultType` | `"detailed"` | ✅ Yes                                 | In addition to what is provided by `"simple"`, the counts of tests passed, passed with retries, failed and skipped. | "Spec failed: 1 test passed, 2 tests failed, 1 test skipped." |
+| `voiceTime`       | `true`       | ✅ Yes                                 | The time of entire spec file run.                                                                                   | "Total time: 34 seconds"                                      |
 
 ## 🏃‍♀️ Voice adjustments
 
@@ -64,42 +64,38 @@ As the plugin does not set a language itself, [`speechSynthesis` is able to dete
 
 > If unset, the app's (i.e. the <html> lang value) lang will be used, or the user-agent default if that is unset too.
 
-## 📕 Example Environment Variable Setups
+## 📕 Example Expose Variable Setups
 
-The following options are suggestions of how to set the environment variable(s). A more comprehensive [guide on environment variable setting](https://docs.cypress.io/guides/guides/environment-variables#Setting) can be found within official Cypress documentation.
+The following options are suggestions of how to set the expose variable(s). A more comprehensive [guide on environment variable setting](https://docs.cypress.io/api/cypress-api/expose#Examples) can be found within official Cypress documentation.
 
-### Setup using `cypress.env.json`
+### Setup using configuration file
 
-Add environment variable(s) to a created `cypress.env.json` file.
+Add environment variable(s) to your Cypress configuration file.
 
 Example:
 
 ```js
-{
+expose: {
   "voiceTime": true,
   "voiceResultType": "detailed",
 }
 ```
 
-This is a useful method for handling local use of this plugin, particularly if you add `cypress.env.json` to your `.gitignore` file. This way, enabling the plugin functionality via environment variable can be different for each developer machine rather than committed to the remote repository.
+### Setup using `--expose`
 
-From official Cypress docs, more information on the [`cypress.env.json` method](https://docs.cypress.io/guides/guides/environment-variables#Option-2-cypressenvjson).
-
-### Setup using `--env`
-
-Alternatively, append the environment variable to the end of your `cypress open` cli command:
+Alternatively, append the expose variable to the end of your `cypress open` cli command:
 
 ```shell
-npx cypress open --env voiceResultType=simple
+npx cypress open --expose voiceResultType=simple
 ```
 
 Or, combine multiple variables in one command to hear both result and total run time:
 
 ```shell
-npx cypress open --env voiceResultType=detailed,voiceTime=true
+npx cypress open --expose voiceResultType=detailed,voiceTime=true
 ```
 
-From official Cypress docs, more information on the [`--env` method](https://docs.cypress.io/guides/guides/environment-variables#Option-4---env).
+From official Cypress docs, more information on the [`--expose` method](https://docs.cypress.io/api/cypress-api/expose#CLI-Flags).
 
 ## TODO
 

--- a/cypress/e2e/combinedResultTime.cy.js
+++ b/cypress/e2e/combinedResultTime.cy.js
@@ -4,15 +4,15 @@
 describe("Voice result and time", () => {
   it(
     "Announces short passing test with result and time",
-    { env: { voiceResultType: "detailed", voiceTime: true } },
+    { expose: { voiceResultType: "detailed", voiceTime: true } },
     () => {
       const synth = window.speechSynthesis;
       synth.speak = (event) => {
         const text = event.text;
         expect(text).to.eq(
-          "Spec passed: 1 test passed. Total time: Less than 1 second."
+          "Spec passed: 1 test passed. Total time: Less than 1 second.",
         );
       };
-    }
+    },
   );
 });

--- a/cypress/e2e/failedVoiceResult.cy.js
+++ b/cypress/e2e/failedVoiceResult.cy.js
@@ -5,7 +5,7 @@ describe("Failing voice", () => {
   it(
     "Announces failed test without time",
     {
-      env: {
+      expose: {
         voiceResultType: "simple",
       },
     },
@@ -25,6 +25,6 @@ describe("Failing voice", () => {
 
         expect(char).to.eq("Spec failed.");
       };
-    }
+    },
   );
 });

--- a/cypress/e2e/passedVoiceResult.cy.js
+++ b/cypress/e2e/passedVoiceResult.cy.js
@@ -4,7 +4,7 @@
 describe("Passing voice", () => {
   it(
     "Announces passed test",
-    { env: { voiceResultType: "simple", voiceTime: false } },
+    { expose: { voiceResultType: "simple", voiceTime: false } },
     () => {
       const synth = window.speechSynthesis;
       synth.speak = (event) => {
@@ -12,6 +12,6 @@ describe("Passing voice", () => {
 
         expect(char).to.eq("Spec passed.");
       };
-    }
+    },
   );
 });

--- a/cypress/e2e/retriedVoiceResult.cy.js
+++ b/cypress/e2e/retriedVoiceResult.cy.js
@@ -6,7 +6,7 @@ describe("Voice on retries", () => {
     "Announces short retried test",
     {
       retries: 1,
-      env: { voiceResultType: "detailed", voiceTime: false },
+      expose: { voiceResultType: "detailed", voiceTime: false },
     },
     () => {
       // this test will fail on first try, but pass on second
@@ -18,10 +18,10 @@ describe("Voice on retries", () => {
         synth.speak = (event) => {
           const text = event.text;
           expect(text).to.eq(
-            "Spec passed with retries: 1 test passed with retries."
+            "Spec passed with retries: 1 test passed with retries.",
           );
         };
       }
-    }
+    },
   );
 });

--- a/cypress/e2e/testResultsOnly.cy.js
+++ b/cypress/e2e/testResultsOnly.cy.js
@@ -4,13 +4,13 @@
 describe("Test results only", () => {
   it(
     "Announces short passing test with only test results",
-    { env: { voiceResultType: "detailed", voiceTime: false } },
+    { expose: { voiceResultType: "detailed", voiceTime: false } },
     () => {
       const synth = window.speechSynthesis;
       synth.speak = (event) => {
         const text = event.text;
         expect(text).to.eq("Spec passed: 1 test passed.");
       };
-    }
+    },
   );
 });

--- a/cypress/e2e/voiceTime.cy.js
+++ b/cypress/e2e/voiceTime.cy.js
@@ -4,13 +4,13 @@
 describe("Voice time", () => {
   it(
     "Announces short passing test with only time",
-    { env: { voiceTime: true, voiceResultType: false } },
+    { expose: { voiceTime: true, voiceResultType: false } },
     () => {
       const synth = window.speechSynthesis;
       synth.speak = (event) => {
         const text = event.text;
         expect(text).to.eq("Total time: Less than 1 second.");
       };
-    }
+    },
   );
 });

--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ import { addStyles } from "./addStyles";
 
 // Voice plugin to announce spec result when Cypress runner UI is open (cypress open)
 if (
-  (Cypress.env("voiceResultType") === "simple" ||
-    Cypress.env("voiceResultType") === "detailed" ||
-    Cypress.env("voiceTime")) &&
+  (Cypress.expose("voiceResultType") === "simple" ||
+    Cypress.expose("voiceResultType") === "detailed" ||
+    Cypress.expose("voiceTime")) &&
   Cypress.config("isInteractive")
 ) {
   // Cancel any ongoing spoken results when a new spec is selected mid-speech
@@ -199,10 +199,10 @@ if (
 
     if (currentTestIsLast) {
       waitForElement(".restart", () => {
-        // Announce spec run result and/or total time based on provided environment variable(s)
+        // Announce spec run result and/or total time based on provided Cypress.expose() variable(s)
         if (
-          Cypress.env("voiceResultType") === "simple" &&
-          !Cypress.env("voiceTime")
+          Cypress.expose("voiceResultType") === "simple" &&
+          !Cypress.expose("voiceTime")
         ) {
           const message = new SpeechSynthesisUtterance(
             `Spec ${
@@ -214,9 +214,9 @@ if (
           message.volume = volume.value;
           speechSynthesis.speak(message);
         } else if (
-          Cypress.env("voiceTime") &&
-          !(Cypress.env("voiceResultType") === "simple") &&
-          !(Cypress.env("voiceResultType") === "detailed")
+          Cypress.expose("voiceTime") &&
+          !(Cypress.expose("voiceResultType") === "simple") &&
+          !(Cypress.expose("voiceResultType") === "detailed")
         ) {
           const message = new SpeechSynthesisUtterance(
             "Total time: " + specTime(),
@@ -226,8 +226,8 @@ if (
           message.volume = volume.value;
           speechSynthesis.speak(message);
         } else if (
-          Cypress.env("voiceResultType") === "detailed" &&
-          !Cypress.env("voiceTime")
+          Cypress.expose("voiceResultType") === "detailed" &&
+          !Cypress.expose("voiceTime")
         ) {
           const message = new SpeechSynthesisUtterance(
             `Spec ${
@@ -243,8 +243,8 @@ if (
           message.volume = volume.value;
           speechSynthesis.speak(message);
         } else if (
-          Cypress.env("voiceResultType") === "simple" &&
-          Cypress.env("voiceTime")
+          Cypress.expose("voiceResultType") === "simple" &&
+          Cypress.expose("voiceTime")
         ) {
           const message = new SpeechSynthesisUtterance(
             `Spec ${
@@ -260,8 +260,8 @@ if (
           message.volume = volume.value;
           speechSynthesis.speak(message);
         } else if (
-          Cypress.env("voiceResultType") === "detailed" &&
-          Cypress.env("voiceTime")
+          Cypress.expose("voiceResultType") === "detailed" &&
+          Cypress.expose("voiceTime")
         ) {
           const message = new SpeechSynthesisUtterance(
             `Spec ${

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cypress-voice-plugin",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-voice-plugin",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
-        "cypress": "^15.8.2"
+        "cypress": "^15.10.0"
       }
     },
     "node_modules/@cypress/request": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.8.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.2.tgz",
-      "integrity": "sha512-KGpuiE8o9l9eyVLPkig574t8zOXkEDKzI0a+RQwy4cfXzpaLipvTOv0t+QEEkLiw/8HbgMNZ0fbPKakJAB3USA==",
+      "version": "15.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.10.0.tgz",
+      "integrity": "sha512-OtUh7OMrfEjKoXydlAD1CfG2BvKxIqgWGY4/RMjrqQ3BKGBo5JFKoYNH+Tpcj4xKxWH4XK0Xri+9y8WkxhYbqQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -582,7 +582,7 @@
         "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
         "listr2": "^3.8.3",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "log-symbols": "^4.0.0",
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
@@ -1310,10 +1310,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-voice-plugin",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Voice plugin for the Cypress Test Runner",
   "main": "./index.js",
   "scripts": {
@@ -13,7 +13,7 @@
     "voice"
   ],
   "devDependencies": {
-    "cypress": "^15.8.2"
+    "cypress": "^15.10.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Major bump to plugin due to Cypress version bump to 15.10.0 with Cypress.expose() migration. 

Additionally, addresses https://github.com/dennisbergevin/cypress-voice-plugin/pull/5
